### PR TITLE
Implement texture filtering (and honor PF_NoSmooth)

### DIFF
--- a/Source/rendering/dxtexturemanager.cpp
+++ b/Source/rendering/dxtexturemanager.cpp
@@ -142,6 +142,7 @@ bool TextureManager::BindTexture(DWORD polygonFlags, const DeusExD3D9TextureHand
     }
     m_llrenderer->ConfigureBlendState(polygonFlags);
     m_llrenderer->ConfigureTextureStageState(0, polygonFlags);
+    m_llrenderer->ConfigureSamplerState(0, polygonFlags);
     return true;
   }
   return false;

--- a/Source/rendering/llrenderer.cpp
+++ b/Source/rendering/llrenderer.cpp
@@ -72,8 +72,6 @@ bool LowlevelRenderer::Initialize(HWND hWnd, uint32_t pWidth, uint32_t pHeight, 
 		GLog->Log(SUCCEEDED(hr) ? L"[EchelonRenderer]\t Reset Direct3D 9 device" : L"[EchelonRenderer]\t Failed to reset D3D9 device");
 	}
 
-	m_Device->GetDeviceCaps(&m_caps);
-
 	if (!SUCCEEDED(hr))
 	{
 		GWarn->Logf(L"[EchelonRenderer-WARN]\t Error code was: %08x", hr);
@@ -110,6 +108,13 @@ bool LowlevelRenderer::Initialize(HWND hWnd, uint32_t pWidth, uint32_t pHeight, 
 		return false;
 	}
 	check(SUCCEEDED(hr));
+
+	hr = m_Device->GetDeviceCaps(&m_caps);
+	if (FAILED(hr))
+	{
+		GWarn->Logf(L"[EchelonRenderer-WARN]\t Unable to pull device caps.  Error code was: %08x", hr);
+		return false;
+	}
 
 	hr = m_Device->CreateDepthStencilSurface(
 		m_outputSurface.width, // Width of the depth buffer surface

--- a/Source/rendering/llrenderer.h
+++ b/Source/rendering/llrenderer.h
@@ -35,8 +35,10 @@ public:
 	void PopDeviceState();
 	HRESULT SetRenderState(D3DRENDERSTATETYPE State,DWORD Value);
 	HRESULT SetTextureStageState(DWORD Stage,D3DTEXTURESTAGESTATETYPE Type,DWORD Value);
+	HRESULT SetSamplerState(DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD Value);
 	void ConfigureBlendState(UnrealBlendFlags pFlags);
 	void ConfigureTextureStageState(int pStageID, UnrealPolyFlags pFlags);
+	void ConfigureSamplerState(int pStageID, UnrealPolyFlags pFlags);
 	void SetProjectionState();
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	std::vector<D3DDISPLAYMODE> GetDisplayModes() const;
@@ -63,9 +65,11 @@ private:
 		static constexpr uint32_t MAX_TEXTURESLOTS = 8;
 		static constexpr uint32_t MAX_TEXTURESTAGES = 8;
 		static constexpr uint32_t MAX_TEXTURESTAGESTATES = 32;
+		static constexpr uint32_t MAX_SAMPLERSTATES = 16;
 		std::optional<IDirect3DTexture9*> m_TextureSlots[MAX_TEXTURESLOTS];
 		std::optional<DWORD> m_RenderStates[MAX_RENDERSTATES];
 		std::optional<DWORD> m_TextureStageStates[MAX_TEXTURESTAGES][MAX_TEXTURESTAGESTATES];
+		std::optional<DWORD> m_SamplerStates[MAX_TEXTURESTAGES][MAX_SAMPLERSTATES];
 		std::optional<uint32_t> m_ViewportLeft;
 		std::optional<uint32_t> m_ViewportTop;
 		std::optional<uint32_t> m_ViewportWidth;
@@ -136,4 +140,6 @@ private:
 		//HWND hwnd{};
 		uint32_t colorBytes = 0;
 	} m_outputSurface;
+
+	D3DCAPS9 m_caps = {};
 };


### PR DESCRIPTION
Quick attempt at adding texture filtering.  It's been a minute since I've done anything with D3D9, but I think this is all OK.  It does look quite a bit better.

Pulled the device caps in initialize to get MaxAnisotropy.  I figure anything that could run RTX Remix probably won't have any issues with anisotropic filtering.

#4 