### PR TITLE
Static meshes are now stable in RTX Remix

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -62,6 +62,7 @@ set(SRC_BASE
 	"utils/materialdebugger.cpp"
 	"hacks/misc.cpp"
 	"hacks/urender.cpp"
+	"hacks/umesh.cpp"
 	"hacks/uengine.cpp"
 	"hacks/fdynamicitemfilter.cpp"
 	"hacks/fscenenode.cpp"

--- a/Source/DeusExEchelonRenderer_PCH.h
+++ b/Source/DeusExEchelonRenderer_PCH.h
@@ -77,6 +77,7 @@ using UnrealBlendFlags = decltype(PF_Translucent|PF_NotSolid);
 using UnrealPolyFlags = decltype(PF_Translucent|PF_NotSolid);
 using Vec3 = D3DXVECTOR3;
 using Vec4 = D3DXVECTOR4;
+inline bool UEFloatEquals(float pValue, float pComparison) { return (pValue > (pComparison-KINDA_SMALL_NUMBER)) && (pValue < (pComparison+KINDA_SMALL_NUMBER)); }
 
 //Frequently used headers
 #include "hacks/misc.h"

--- a/Source/hacks/bytepatches.cpp
+++ b/Source/hacks/bytepatches.cpp
@@ -58,6 +58,39 @@ void InstallBytePatches()
       }
     }
 
+    //Disable culling & clipping of lodmeshes..
+    if (true)
+    {
+      uint32_t coreModule = reinterpret_cast<uint32_t>(GetModuleHandleA("render.dll"));
+      constexpr std::pair<uint32_t,uint32_t> patches[] = {
+        {0x0000C52A, 0x90}, /*outcode rejection in RenderSubsurface*/
+        {0x0000C52B, 0x90}, 
+        {0x0000C571, 0xEB}, /*backface rejection in RenderSubsurface*/
+        {0x0000C592, 0xE9}, /*clipping following outcode for all three vertices,  in RenderSubsurface*/
+        {0x0000C593, 0x79},
+        {0x0000C594, 0x05},
+        {0x0000C595, 0x00},
+        {0x0000C597, 0x90},
+        {0x0000CB32, 0xEB}, /* Frustrum near clipping in RenderSubsurface */
+        {0x0000CB9A, 0xEB}, /* Rasterization clipping in RenderSubsurface */
+        {0x0000FC54, 0x90}, /* Clipping from outcode in DrawLodMesh */
+        {0x0000FC55, 0x90},
+        {0x0000FC56, 0x90},
+        {0x0000FC57, 0x90},
+        {0x0000FC58, 0x90},
+        {0x0000FC59, 0x90},
+      };
+      DWORD oldProtect = 0;
+      for (auto patch : patches)
+      {
+        if (VirtualProtect(LPVOID(coreModule + patch.first), 4 * 2, PAGE_READWRITE, &oldProtect))
+        {
+          *reinterpret_cast<uint8_t*>(uint32_t(coreModule) + patch.first) = patch.second;
+          VirtualProtect(LPVOID(coreModule + patch.first), 4 * 2, oldProtect, &oldProtect);
+        }
+      }
+    }
+
     if (true)
     {
       constexpr uint32_t newMaxPoints = MAX_POINTS * 2;

--- a/Source/hacks/hacks.h
+++ b/Source/hacks/hacks.h
@@ -3,6 +3,7 @@
 extern void InstallFSceneNodeHacks();
 extern void InstallFSpanBufferHacks();
 extern void InstallURenderHacks();
+extern void InstallUMeshHacks();
 extern void InstallUGameEngineHacks();
 extern void InstallFDynamicItemFilterHacks();
 extern void InstallThreadAffinityHacks();
@@ -12,6 +13,7 @@ extern void InstallRTXConfigPatches();
 extern void UninstallFSceneNodeHacks();
 extern void UninstallFSpanBufferHacks();
 extern void UninstallURenderHacks();
+extern void UninstallUMeshHacks();
 extern void UninstallUGameEngineHacks();
 extern void UninstallFDynamicItemFilterHacks();
 extern void UninstallThreadAffinityHacks();

--- a/Source/hacks/misc.h
+++ b/Source/hacks/misc.h
@@ -49,11 +49,10 @@ public:
 			FActorLink* Volumetrics = nullptr;
 			DWORD PolyFlags = 0;
 			UTexture* LastTextureInfo = nullptr;
+			bool InViewSpace = false;
 			std::optional<TextureMetaData> LastTextureMetadata;
-			D3DXMATRIX worldMatrix{};
-			D3DXMATRIX worldMatrixInv{};
-			D3DXMATRIX localToViewMatrix{};
-			D3DXMATRIX viewToLocalMatrix{};
+			std::optional<D3DXMATRIX> worldMatrix;
+			std::optional<D3DXMATRIX> worldMatrixInv;
 			DrawCall() = default;
 		};
 		std::optional<DrawCall> drawcallInfo;
@@ -169,5 +168,6 @@ namespace Misc /*should probably rename to util*/
 						reinterpret_cast<uint64_t>(pAddress) <= (moduleStart + baseOffsetMax) &&
 						reinterpret_cast<uint64_t>(pAddress) < moduleEnd);
 	}
-
 }
+
+extern D3DXMATRIX UECoordsToMatrix(const FCoords& pCoords, D3DXMATRIX* pInverse=nullptr);

--- a/Source/hacks/umesh.cpp
+++ b/Source/hacks/umesh.cpp
@@ -1,0 +1,92 @@
+#include "DeusExEchelonRenderer_PCH.h"
+#pragma hdrstop
+
+#include "misc.h"
+#include "hacks.h"
+#include "uefacade.h"
+#include "utils/debugmenu.h"
+#include <polyhook2/Detour/NatDetour.hpp>
+#include <polyhook2/Virtuals/VFuncSwapHook.hpp>
+
+
+namespace Hacks
+{  
+  std::vector<std::shared_ptr<PLH::IHook>> UMeshDetours;
+  namespace UMeshVTableFuncs
+  {
+    void(__thiscall *GetFrame)(ULodMesh* pThis, FVector* Verts, INT Size, FCoords Coords, AActor* Owner) = nullptr;
+  }
+  namespace ULodMeshFuncs
+  {
+    HookableFunction GetFrame = &ULodMesh::GetFrame;
+  }
+
+  struct UMeshOverride
+  {
+    void GetFrame(FVector* Verts, INT	Size, FCoords	Coords, AActor* Owner)
+    {
+      UMeshVTableFuncs::GetFrame(reinterpret_cast<ULodMesh*>(this), Verts, Size, Coords, Owner);
+    }
+  };
+
+  struct ULodMeshOverride
+  {
+    void GetFrame(FVector* Verts, INT Size, FCoords Coords, AActor* Owner, INT& LODRequest)
+    {
+      auto ctx = g_ContextManager.GetContext();
+
+      //Kept in case we want to intercept the animation frames...
+      (reinterpret_cast<ULodMesh*>(this)->*ULodMeshFuncs::GetFrame)(Verts, Size, Coords, Owner, LODRequest);
+    }
+  };
+
+  namespace UMeshVTableOverrides
+  {
+    void(UMeshOverride::* GetFrame)(FVector* Verts, INT Size, FCoords Coords, AActor* Owner) = &UMeshOverride::GetFrame;
+  }
+  namespace ULodMeshOverrides
+  {
+    auto GetFrame = &ULodMeshOverride::GetFrame;
+  }
+
+  std::tuple<PLH::VFuncMap::value_type, uint64_t, PLH::VFuncMap> UMeshMappedVTableFuncs[] = {
+    {{(uint16_t)28, *(uint64_t*)&UMeshVTableOverrides::GetFrame}, (uint64_t)&UMeshVTableFuncs::GetFrame, {}},
+  };
+}
+
+void InstallUMeshHacks()
+{
+  using namespace Hacks;
+
+  UMeshDetours.push_back(std::make_shared<PLH::NatDetour>(*(uint64_t*)&ULodMeshFuncs::GetFrame, *(uint64_t*)&ULodMeshOverrides::GetFrame, &ULodMeshFuncs::GetFrame.func64));
+  for (auto& detour : UMeshDetours)
+  {
+    detour->hook();
+  }
+
+  TObjectIterator<UMesh> ObjectIt;
+  auto aLodMesh = *ObjectIt;
+  for (auto& func : UMeshMappedVTableFuncs)
+  {
+    auto funcDescriptor = std::get<0>(func);
+    uint32_t* origFuncPtr = reinterpret_cast<uint32_t*>(std::get<1>(func));
+    PLH::VFuncMap* origFuncMap = &std::get<2>(func);
+    origFuncMap->clear();
+    PLH::VFuncMap v = { funcDescriptor };
+    auto ptr = std::make_shared<PLH::VFuncSwapHook>(reinterpret_cast<uint64_t>(aLodMesh), v, origFuncMap);
+    ptr->hook();
+    *origFuncPtr = (*origFuncMap)[funcDescriptor.first];
+    UMeshDetours.push_back(std::move(ptr));
+  }
+}
+
+void UninstallUMeshHacks()
+{
+  using namespace Hacks;
+  for (auto& detour : UMeshDetours)
+  {
+    detour->unHook();
+  }
+  ULodMeshFuncs::GetFrame.Restore();
+  UMeshDetours.clear();
+}

--- a/Source/rendering/hlrenderer.h
+++ b/Source/rendering/hlrenderer.h
@@ -12,7 +12,7 @@
 class HighlevelRenderer
 {
 public:
-	enum class ViewType { identity, game };
+	enum class ViewType { identity, engine, game };
 	enum class ProjectionType { identity, orthogonal, uiorthogonal, perspective };
 public:
 	void Initialize(LowlevelRenderer* pLLRenderer);
@@ -20,6 +20,8 @@ public:
 
 	void OnLevelChange();
 
+	void SetWorldTransformStateToIdentity();
+	void SetWorldTransformState(const D3DXMATRIX& pMatrix);
 	void SetViewState(FSceneNode* Frame, ViewType viewType);
 	void SetProjectionState(FSceneNode* Frame, ProjectionType projection);
 
@@ -39,7 +41,6 @@ public:
 	void OnDrawUIBegin(FSceneNode* Frame);
 	void OnDrawUI(FSceneNode* Frame, FTextureInfo& TextureInfo, float pX, float pY, float pWidth, float pHeight, float pTexCoordU, float pTexCoordV, float pTexCoordUL, float pTexCoordVL, FSpanBuffer* Span, float pZDepth, FPlane pColor, FPlane pFog, DWORD pPolyFlags);
 	void OnDrawUIEnd(FSceneNode* Frame);
-	void GetWorldMatrix(FSceneNode* Frame, const FCoords& Coords, D3DXMATRIX* worldMatrix, D3DXMATRIX* worldMatrixInverse);
 	void GetViewMatrix(FSceneNode* Frame, D3DXMATRIX& viewMatrix);
 	void GetPerspectiveProjectionMatrix(FSceneNode* Frame, D3DXMATRIX& projMatrix);
 

--- a/Source/rendering/llrenderer.h
+++ b/Source/rendering/llrenderer.h
@@ -27,8 +27,11 @@ public:
 	void EndScene();
 	void BeginFrame();
 	void EndFrame();
+	
+	void SetWorldMatrix(const D3DMATRIX& pMatrix);
 	void SetViewMatrix(const D3DMATRIX& pMatrix);
 	void SetProjectionMatrix(const D3DMATRIX& pMatrix);
+
 	bool ResizeDisplaySurface(uint32_t pLeft, uint32_t pTop, uint32_t pWidth, uint32_t pHeight, bool pFullscreen);
 	bool ValidateViewport(uint32_t pLeft, uint32_t pTop, uint32_t pWidth, uint32_t pHeight);
 	void PushDeviceState();
@@ -45,10 +48,10 @@ public:
 	D3DDISPLAYMODE FindClosestResolution(uint32_t pWidth, uint32_t pHeight) const;
 	void ClearDepth() {/*TODO?*/ };
 	void ClearDisplaySurface(const Vec4& clearColor);
-	void RenderTriangleListBuffer(const D3DXMATRIX& pWm, DWORD pFVF, const void* pVertices, const uint32_t primitiveCount, const uint32_t pVertexCount, const uint32_t pVertexSize, const uint32_t pHash, const uint32_t pDebug);
-	void RenderTriangleList(const D3DXMATRIX& pWm, const VertexPos3Tex0to4* pVertices, const uint32_t pPrimitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug);
-	void RenderTriangleList(const D3DXMATRIX& pWm, const VertexPos3Tex0* pVertices, const uint32_t pPrimitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug);
-	void RenderTriangleList(const D3DXMATRIX& pWm, const VertexPos4Color0Tex0* pVertices, const uint32_t primitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug);
+	void RenderTriangleListBuffer(DWORD pFVF, const void* pVertices, const uint32_t primitiveCount, const uint32_t pVertexCount, const uint32_t pVertexSize, const uint32_t pHash, const uint32_t pDebug);
+	void RenderTriangleList(const VertexPos3Tex0to4* pVertices, const uint32_t pPrimitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug);
+	void RenderTriangleList(const VertexPos3Tex0* pVertices, const uint32_t pPrimitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug);
+	void RenderTriangleList(const VertexPos4Color0Tex0* pVertices, const uint32_t primitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug);
 	void RenderLight(int32_t index, const D3DLIGHT9& pLight);
 	void FlushLights();
 
@@ -74,6 +77,7 @@ private:
 		std::optional<uint32_t> m_ViewportTop;
 		std::optional<uint32_t> m_ViewportWidth;
 		std::optional<uint32_t> m_ViewportHeight;
+		std::optional<D3DMATRIX> m_WorldMatrix;
 		std::optional<D3DMATRIX> m_ViewMatrix;
 		std::optional<D3DMATRIX> m_ProjectionMatrix;
 	} m_States[8];

--- a/Source/uefacade.cpp
+++ b/Source/uefacade.cpp
@@ -84,6 +84,7 @@ UBOOL UD3D9FPRenderDevice::Init(UViewport* pInViewport,int32_t pWidth, int32_t p
 	InstallFSceneNodeHacks();
 	InstallFSpanBufferHacks();
 	InstallURenderHacks();
+	InstallUMeshHacks();
 	InstallUGameEngineHacks();
 	InstallFDynamicItemFilterHacks();
 
@@ -170,6 +171,7 @@ void UD3D9FPRenderDevice::Exit()
 #endif
 	UninstallFDynamicItemFilterHacks();
 	UninstallURenderHacks();
+	UninstallUMeshHacks();
 	UninstallFSpanBufferHacks();
 	UninstallFSceneNodeHacks();
 	UninstallThreadAffinityHacks();

--- a/Source/utils/debugmenu.cpp
+++ b/Source/utils/debugmenu.cpp
@@ -308,6 +308,8 @@ void DebugMenu::Update()
     //io.DisplayFramebufferScale.y = dpiScale;
   }
   
+
+
 #if 1
   for (auto& categoryPair : m_DebugItems)
   {

--- a/Source/utils/debugmenu.h
+++ b/Source/utils/debugmenu.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstdarg>
 #include <map>
+#include <mutex>
 
 #ifndef TOKENIZE
 #define TOKENIZE2(s) #s

--- a/Source/utils/materialdebugger.cpp
+++ b/Source/utils/materialdebugger.cpp
@@ -85,6 +85,10 @@ namespace
 
 void MaterialDebugger::Update(FSceneNode* Frame)
 {
+	{
+		
+	}
+	///
 	FVector dir = -(Frame->Coords.XAxis ^ Frame->Coords.YAxis);
 	FVector begin = Frame->Coords.Origin;
 	FVector end = Frame->Coords.Origin + dir*1000000.0f;
@@ -115,14 +119,17 @@ void MaterialDebugger::Update(FSceneNode* Frame)
 						{
 							const auto& surf = levelModel->Surfs(iSurf);
 							const auto texture = surf.Texture;
-							FTextureInfo info{};
-							texture->Lock(info, 0, 0, GRenderDevice);
-							textureID = info.CacheID;
-							surfFlags = surf.PolyFlags;
-							textureFlags = texture->PolyFlags;
-							g_DebugMenu.VisitTexture(&info);
-							texture->Unlock(info);
-							break;
+							if (texture)
+							{
+								FTextureInfo info{};
+								texture->Lock(info, 0, 0, GRenderDevice);
+								textureID = info.CacheID;
+								surfFlags = surf.PolyFlags;
+								textureFlags = texture->PolyFlags;
+								g_DebugMenu.VisitTexture(&info);
+								texture->Unlock(info);
+								break;
+							}
 						}
 					}
 				}
@@ -386,9 +393,9 @@ void MaterialDebugger::exportHashMappings(bool pLoadAllTextures)
 		//Do a dummy render call so that Remix picks up the texture
 		{
 			textureManager.BindTexture(texture->PolyFlags, md);
-			static D3DMATRIX identity = []() { D3DXMATRIX m; D3DXMatrixIdentity(&m); return m; }();
+			hlRenderer->SetWorldTransformStateToIdentity();
 			static LowlevelRenderer::VertexPos3Tex0to4 vbuffer;
-			llRenderer->RenderTriangleList(identity, &vbuffer, 1, 1, 0, 0);
+			llRenderer->RenderTriangleList( &vbuffer, 1, 1, 0, 0);
 		}
 
 		if (textureInfo.Texture != nullptr)


### PR DESCRIPTION
This was done by tricking DX/UE to render the mesh in local space (at origin, with no rotation) and then re-calculating the appropriate worldmatrix.

Meshes that are actively animating, however, are not (yet) stable, as each frame is interpolated.