### PR TITLE
gouraud shading

### DIFF
--- a/Source/rendering/hlrenderer.cpp
+++ b/Source/rendering/hlrenderer.cpp
@@ -798,17 +798,20 @@ void HighlevelRenderer::OnDrawMesh(FSceneNode* Frame, FTextureInfo& Info, FTrans
 
 	const auto& md = (*renderContext->drawcallInfo->LastTextureMetadata);
 	FVector vtx[3]{ firstVertexInfo->Point, {}, {}};
+	FVector nrm[3]{ firstVertexInfo->Normal, {}, {}};
 	for (int i = 2; i < NumPts; i++)
 	{
 		vtx[1] = Pts[i - 1]->Point;
 		vtx[2] = Pts[i]->Point;
+		nrm[1] = Pts[i - 1]->Normal;
+		nrm[2] = Pts[i]->Normal;
 
 		auto fixSigned0 = [](float& value) {
 			if (value >= 0.0f && std::signbit(value)) { value = std::abs(value); }
 		};
-		auto d3dvtx0 = LowlevelRenderer::VertexPos3Tex0{ {vtx[0].X, vtx[0].Y, vtx[0].Z}, {md.multU * Pts[0]->U,			  md.multV * Pts[0]->V } };
-		auto d3dvtx1 = LowlevelRenderer::VertexPos3Tex0{ {vtx[1].X, vtx[1].Y, vtx[1].Z}, {md.multU * Pts[i - 1]->U,  md.multV * Pts[i - 1]->V }};
-		auto d3dvtx2 = LowlevelRenderer::VertexPos3Tex0{ {vtx[2].X, vtx[2].Y, vtx[2].Z}, { md.multU * Pts[i]->U,				md.multV * Pts[i]->V }};
+		auto d3dvtx0 = LowlevelRenderer::VertexPos3Norm3Tex0{ {vtx[0].X, vtx[0].Y, vtx[0].Z}, {nrm[0].X, nrm[0].Y, nrm[0].Z}, {md.multU* Pts[0]->U,			  md.multV* Pts[0]->V } };
+		auto d3dvtx1 = LowlevelRenderer::VertexPos3Norm3Tex0{ {vtx[1].X, vtx[1].Y, vtx[1].Z}, {nrm[1].X, nrm[1].Y, nrm[1].Z}, {md.multU * Pts[i - 1]->U,  md.multV * Pts[i - 1]->V }};
+		auto d3dvtx2 = LowlevelRenderer::VertexPos3Norm3Tex0{ {vtx[2].X, vtx[2].Y, vtx[2].Z}, {nrm[2].X, nrm[2].Y, nrm[2].Z}, { md.multU * Pts[i]->U,				md.multV * Pts[i]->V }};
 
 		mesh.buffer->push_back(std::move(d3dvtx0));
 		mesh.buffer->push_back(std::move(d3dvtx1));
@@ -899,7 +902,7 @@ void HighlevelRenderer::OnDrawMeshEnd(FSceneNode* Frame, AActor* Owner)
 			if (diff > 2.0f || isAnimating)
 			{
 				dynamicMeshInfo.lastVertexSum = vertexSum;
-				const uint32_t meshHash = appMemCrc(buffer->data(), buffer->size() * sizeof(LowlevelRenderer::VertexPos3Tex0));
+				const uint32_t meshHash = appMemCrc(buffer->data(), buffer->size() * sizeof(LowlevelRenderer::VertexPos3Norm3Tex0));
 				m_LLRenderer->RenderTriangleList(buffer->data(), buffer->size() / 3, buffer->size(), meshHash, meshIndex);
 				dynamicMeshInfo.lastDrawcallHash = meshHash;
 			}

--- a/Source/rendering/hlrenderer.h
+++ b/Source/rendering/hlrenderer.h
@@ -49,7 +49,7 @@ private:
 	using DynamicMeshesKey = uint32_t;
 	using StaticMeshesKey = uint32_t;
 	using UIMeshesVertexBuffer = std::vector<LowlevelRenderer::VertexPos4Color0Tex0>;
-	using DynamicMeshesVertexBuffer = std::vector<LowlevelRenderer::VertexPos3Tex0>;
+	using DynamicMeshesVertexBuffer = std::vector<LowlevelRenderer::VertexPos3Norm3Tex0>;
 	using StaticMeshesVertexBuffer = std::vector<LowlevelRenderer::VertexPos3Tex0>;
 
 	struct StaticMeshesValue {

--- a/Source/rendering/llrenderer.cpp
+++ b/Source/rendering/llrenderer.cpp
@@ -314,6 +314,19 @@ void LowlevelRenderer::RenderTriangleList(const LowlevelRenderer::VertexPos3Tex0
 	);
 }
 
+void LowlevelRenderer::RenderTriangleList(const LowlevelRenderer::VertexPos3Norm3Tex0* pVertices, const uint32_t primitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug)
+{
+	return RenderTriangleListBuffer(
+		D3DFVF_XYZ | D3DFVF_NORMAL | /*D3DFVF_DIFFUSE |*/ D3DFVF_TEX1 /*| D3DFVF_TEX2 | D3DFVF_TEX3 | D3DFVF_TEX4 | D3DFVF_TEX5*/,
+		pVertices,
+		primitiveCount,
+		pVertexCount,
+		sizeof(LowlevelRenderer::VertexPos3Norm3Tex0),
+		pHash,
+		pDebug
+	);
+}
+
 void LowlevelRenderer::RenderTriangleList(const LowlevelRenderer::VertexPos3Tex0to4* pVertices, const uint32_t primitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug)
 {
 	return RenderTriangleListBuffer(

--- a/Source/rendering/llrenderer.h
+++ b/Source/rendering/llrenderer.h
@@ -13,6 +13,7 @@ class LowlevelRenderer
 	friend class MaterialDebugger;
 public:
 	struct VertexPos3Tex0;
+	struct VertexPos3Norm3Tex0;
 	struct VertexPos3Tex0to4;
 	struct VertexPos4Color0Tex0;
 	struct VertexPos3Color0;
@@ -50,6 +51,7 @@ public:
 	void ClearDisplaySurface(const Vec4& clearColor);
 	void RenderTriangleListBuffer(DWORD pFVF, const void* pVertices, const uint32_t primitiveCount, const uint32_t pVertexCount, const uint32_t pVertexSize, const uint32_t pHash, const uint32_t pDebug);
 	void RenderTriangleList(const VertexPos3Tex0to4* pVertices, const uint32_t pPrimitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug);
+	void RenderTriangleList(const VertexPos3Norm3Tex0* pVertices, const uint32_t pPrimitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug);
 	void RenderTriangleList(const VertexPos3Tex0* pVertices, const uint32_t pPrimitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug);
 	void RenderTriangleList(const VertexPos4Color0Tex0* pVertices, const uint32_t primitiveCount, const uint32_t pVertexCount, const uint32_t pHash, const uint32_t pDebug);
 	void DisableLight(int32_t index);
@@ -91,6 +93,13 @@ private:
 	struct VertexPos3Tex0
 	{
 		D3DXVECTOR3 Pos;
+		D3DXVECTOR2 Tex0;
+	};
+
+	struct VertexPos3Norm3Tex0
+	{
+		D3DXVECTOR3 Pos;
+		D3DXVECTOR3 Normal;
 		D3DXVECTOR2 Tex0;
 	};
 


### PR DESCRIPTION
was already enabled, but feeding meshes' normals into the vertex buffer lets it actually work.  Objects only for now, not implemented for level geometry